### PR TITLE
Add release workflow and Rust 1.85 build fix

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -18,6 +18,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xdotool
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Validate debug build
+        run: cargo check --locked
+      - name: Validate tests
+        run: cargo test --locked
       - name: Build release binary
         run: cargo build --release --locked
       - name: Package release artifact

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,35 @@
+name: ci-release
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install xdotool
+        run: sudo apt-get update && sudo apt-get install -y xdotool
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release binary
+        run: cargo build --release --locked
+      - name: Package release artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        run: tar -C target/release -czf rmcp-xdotool-linux-x86_64.tar.gz rmcp-xdotool
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rmcp-xdotool-linux-x86_64
+          path: target/release/rmcp-xdotool
+      - name: Publish GitHub release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: rmcp-xdotool-linux-x86_64.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -115,10 +115,11 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -128,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
@@ -158,6 +159,12 @@ name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -478,9 +485,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rmcp"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa"
+checksum = "5df440eaa43f8573491ed4a5899719b6d29099500774abba12214a095a4083ed"
 dependencies = [
  "async-trait",
  "base64",
@@ -500,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f81daaa494eb8e985c9462f7d6ce1ab05e5299f48aafd76cdd3d8b060e6f59"
+checksum = "9ef03779cccab8337dd8617c53fce5c98ec21794febc397531555472ca28f8c3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["mcp", "xdotool", "automation", "mouse", "keyboard"]
 categories = ["development-tools"]
 
 [dependencies]
-rmcp = { version = "0.12", features = ["server", "transport-io"] }
+rmcp = { version = "0.11", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 schemars = "1.0"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@ MCP server for mouse and keyboard automation via xdotool. Gives Claude (or any M
 ## Installation
 
 ```bash
-cargo install rmcp-xdotool
+cargo install --locked rmcp-xdotool
 ```
+
+Or download the latest Linux binary from [GitHub Releases](https://github.com/sqrew/rmcp-xdotool/releases).
 
 Or build from source:
 ```bash
 git clone https://github.com/sqrew/rmcp-xdotool
 cd rmcp-xdotool
-cargo build --release
+cargo build --release --locked
 ```
 
 ## Requirements
@@ -49,6 +51,14 @@ Add to your `~/.claude.json`:
   }
 }
 ```
+
+## GitHub Releases
+
+Pushing a tag like `v0.2.1` triggers GitHub Actions to:
+
+- build the release binary on Ubuntu
+- upload the binary as a workflow artifact
+- attach `rmcp-xdotool-linux-x86_64.tar.gz` to the GitHub release for that tag
 
 ## Usage Examples
 


### PR DESCRIPTION
Adds release builds.
Also fixes the Rust 1.85 build problem.

Validation:
- cargo check --locked
- cargo test --locked

Refs:
- #2
