### PR TITLE
Add selected window context

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ cargo build --release
 | `scroll` | Scroll up/down/left/right |
 | `get_mouse_position` | Get current cursor position |
 | `double_click` | Double-click at current position |
+| `select_window` | Save a selected window ID |
+| `select_active_window` | Save the active window |
+| `get_selected_window` | Show the selected window |
+| `clear_selected_window` | Clear the selected window |
 
 ## Claude Code Configuration
 
@@ -58,6 +62,7 @@ Claude, click the button at position (800, 450)
 Claude, type "hello world" into the search box
 Claude, press ctrl+s to save
 Claude, scroll down 5 clicks
+Claude, select the active window and keep typing there
 ```
 
 ## Warning

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ cargo build --release
 | `double_click` | Double-click at current position |
 | `select_window` | Save a selected window ID |
 | `select_active_window` | Save the active window |
+| `select_first_window` | Search and save one matching window |
 | `get_selected_window` | Show the selected window |
+| `describe_selected_window` | Show selected window name and geometry |
+| `focus_selected_window` | Focus the selected window |
+| `click_selected_window_center` | Click the selected window center |
 | `clear_selected_window` | Clear the selected window |
 
 ## Claude Code Configuration
@@ -63,6 +67,8 @@ Claude, type "hello world" into the search box
 Claude, press ctrl+s to save
 Claude, scroll down 5 clicks
 Claude, select the active window and keep typing there
+Claude, search for Slack and select the first match
+Claude, focus the selected window and click its center
 ```
 
 ## Warning

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,14 +199,25 @@ impl XdotoolServer {
         let output = Self::run_xdotool(&args)?;
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).lines().map(str::to_string).collect())
-        } else {
+        } else if String::from_utf8_lossy(&output.stderr).trim().is_empty() {
             Ok(vec![])
+        } else {
+            Err(Self::xdotool_error(&output))
         }
     }
 
     fn window_name(&self, window_id: &str) -> Option<String> {
         let output = Self::run_xdotool(&["getwindowname", window_id]).ok()?;
         output.status.success().then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    fn active_window_id(&self) -> Result<String, McpError> {
+        let output = Self::run_xdotool(&["getactivewindow"])?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            Err(Self::xdotool_error(&output))
+        }
     }
 
     fn window_geometry(&self, window_id: &str) -> Result<(i32, i32, i32, i32, i32), McpError> {
@@ -234,6 +245,10 @@ impl XdotoolServer {
             }
         }
         Ok((x, y, width, height, screen))
+    }
+
+    fn ensure_window_exists(&self, window_id: &str) -> Result<(), McpError> {
+        self.window_geometry(window_id).map(|_| ())
     }
 }
 
@@ -496,6 +511,7 @@ impl XdotoolServer {
         &self,
         Parameters(params): Parameters<SelectWindowParams>,
     ) -> Result<CallToolResult, McpError> {
+        self.ensure_window_exists(&params.window_id)?;
         self.set_selected_window(params.window_id.clone())?;
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Selected window: {}",
@@ -512,6 +528,7 @@ impl XdotoolServer {
         let window_id = window_ids.get(params.index).cloned().ok_or_else(|| {
             McpError::internal_error(format!("No window found matching '{}'", params.query), None)
         })?;
+        self.ensure_window_exists(&window_id)?;
         self.set_selected_window(window_id.clone())?;
         let name = self.window_name(&window_id).unwrap_or_else(|| "<unknown>".to_string());
         Ok(CallToolResult::success(vec![Content::text(format!(
@@ -522,24 +539,13 @@ impl XdotoolServer {
 
     #[rmcp::tool(description = "Save the current active window as the selected window")]
     pub async fn select_active_window(&self) -> Result<CallToolResult, McpError> {
-        let output = Command::new("xdotool")
-            .args(["getactivewindow"])
-            .output()
-            .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
-
-        if output.status.success() {
-            let window_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            self.set_selected_window(window_id.clone())?;
-            Ok(CallToolResult::success(vec![Content::text(format!(
-                "Selected active window: {}",
-                window_id
-            ))]))
-        } else {
-            Err(McpError::internal_error(
-                format!("xdotool error: {}", String::from_utf8_lossy(&output.stderr)),
-                None
-            ))
-        }
+        let window_id = self.active_window_id()?;
+        self.ensure_window_exists(&window_id)?;
+        self.set_selected_window(window_id.clone())?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Selected active window: {}",
+            window_id
+        ))]))
     }
 
     #[rmcp::tool(description = "Show the selected window, if one is set")]
@@ -621,22 +627,10 @@ impl XdotoolServer {
 
     #[rmcp::tool(description = "Get the currently focused/active window ID")]
     pub async fn get_active_window(&self) -> Result<CallToolResult, McpError> {
-        let output = Command::new("xdotool")
-            .args(["getactivewindow"])
-            .output()
-            .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
-
-        if output.status.success() {
-            let window_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            Ok(CallToolResult::success(vec![Content::text(
-                format!("Active window ID: {}", window_id)
-            )]))
-        } else {
-            Err(McpError::internal_error(
-                format!("xdotool error: {}", String::from_utf8_lossy(&output.stderr)),
-                None
-            ))
-        }
+        let window_id = self.active_window_id()?;
+        Ok(CallToolResult::success(vec![Content::text(
+            format!("Active window ID: {}", window_id)
+        )]))
     }
 
     #[rmcp::tool(description = "Get window geometry (position and size) for a window ID")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,18 @@ pub struct SearchWindowParams {
 fn default_search_type() -> String { "any".to_string() }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchSelectWindowParams {
+    #[schemars(description = "Search query (window name, class, or pattern)")]
+    pub query: String,
+    #[schemars(description = "Search by: 'name', 'class', 'classname', or 'any' (default: 'any')")]
+    #[serde(default = "default_search_type")]
+    pub search_type: String,
+    #[schemars(description = "Which match to select. Default: 0")]
+    #[serde(default)]
+    pub index: usize,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct WindowIdParams {
     #[schemars(description = "Optional window ID. Defaults to the selected window when set.")]
     #[serde(default)]
@@ -159,6 +171,69 @@ impl XdotoolServer {
             Some(window_id) => Ok(Some(window_id.to_string())),
             None => self.selected_window(),
         }
+    }
+
+    fn run_xdotool(args: &[&str]) -> Result<std::process::Output, McpError> {
+        Command::new("xdotool")
+            .args(args)
+            .output()
+            .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))
+    }
+
+    fn xdotool_error(output: &std::process::Output) -> McpError {
+        McpError::internal_error(
+            format!("xdotool error: {}", String::from_utf8_lossy(&output.stderr)),
+            None
+        )
+    }
+
+    fn search_window_ids(&self, query: &str, search_type: &str) -> Result<Vec<String>, McpError> {
+        let mut args = vec!["search"];
+        match search_type.to_lowercase().as_str() {
+            "name" => args.push("--name"),
+            "class" => args.push("--class"),
+            "classname" => args.push("--classname"),
+            _ => {}
+        }
+        args.push(query);
+        let output = Self::run_xdotool(&args)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).lines().map(str::to_string).collect())
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    fn window_name(&self, window_id: &str) -> Option<String> {
+        let output = Self::run_xdotool(&["getwindowname", window_id]).ok()?;
+        output.status.success().then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    fn window_geometry(&self, window_id: &str) -> Result<(i32, i32, i32, i32, i32), McpError> {
+        let output = Self::run_xdotool(&["getwindowgeometry", "--shell", window_id])?;
+        if !output.status.success() {
+            return Err(Self::xdotool_error(&output));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut x = 0;
+        let mut y = 0;
+        let mut width = 0;
+        let mut height = 0;
+        let mut screen = 0;
+        for line in stdout.lines() {
+            if line.starts_with("X=") {
+                x = line[2..].parse().unwrap_or(0);
+            } else if line.starts_with("Y=") {
+                y = line[2..].parse().unwrap_or(0);
+            } else if line.starts_with("WIDTH=") {
+                width = line[6..].parse().unwrap_or(0);
+            } else if line.starts_with("HEIGHT=") {
+                height = line[7..].parse().unwrap_or(0);
+            } else if line.starts_with("SCREEN=") {
+                screen = line[7..].parse().unwrap_or(0);
+            }
+        }
+        Ok((x, y, width, height, screen))
     }
 }
 
@@ -393,10 +468,7 @@ impl XdotoolServer {
 
         args.push(&params.query);
 
-        let output = Command::new("xdotool")
-            .args(&args)
-            .output()
-            .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
+        let output = Self::run_xdotool(&args)?;
 
         if output.status.success() {
             let stdout = String::from_utf8_lossy(&output.stdout);
@@ -431,6 +503,23 @@ impl XdotoolServer {
         ))]))
     }
 
+    #[rmcp::tool(description = "Search for windows and save one match as the selected window")]
+    pub async fn select_first_window(
+        &self,
+        Parameters(params): Parameters<SearchSelectWindowParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let window_ids = self.search_window_ids(&params.query, &params.search_type)?;
+        let window_id = window_ids.get(params.index).cloned().ok_or_else(|| {
+            McpError::internal_error(format!("No window found matching '{}'", params.query), None)
+        })?;
+        self.set_selected_window(window_id.clone())?;
+        let name = self.window_name(&window_id).unwrap_or_else(|| "<unknown>".to_string());
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Selected window: {} ({})",
+            window_id, name
+        ))]))
+    }
+
     #[rmcp::tool(description = "Save the current active window as the selected window")]
     pub async fn select_active_window(&self) -> Result<CallToolResult, McpError> {
         let output = Command::new("xdotool")
@@ -457,7 +546,10 @@ impl XdotoolServer {
     pub async fn get_selected_window(&self) -> Result<CallToolResult, McpError> {
         Ok(CallToolResult::success(vec![Content::text(
             match self.selected_window()? {
-                Some(window_id) => format!("Selected window: {}", window_id),
+                Some(window_id) => match self.window_name(&window_id) {
+                    Some(name) if !name.is_empty() => format!("Selected window: {} ({})", window_id, name),
+                    _ => format!("Selected window: {}", window_id),
+                },
                 None => "No window selected".to_string(),
             }
         )]))
@@ -469,6 +561,62 @@ impl XdotoolServer {
         Ok(CallToolResult::success(vec![Content::text(
             "Cleared selected window".to_string()
         )]))
+    }
+
+    #[rmcp::tool(description = "Focus the selected window")]
+    pub async fn focus_selected_window(&self) -> Result<CallToolResult, McpError> {
+        let window_id = self
+            .selected_window()?
+            .ok_or_else(|| McpError::internal_error("No window selected. Use select_window/select_active_window/select_first_window first.", None))?;
+        let output = Self::run_xdotool(&["windowactivate", "--sync", &window_id])?;
+        if output.status.success() {
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Focused window: {}",
+                window_id
+            ))]))
+        } else {
+            Err(Self::xdotool_error(&output))
+        }
+    }
+
+    #[rmcp::tool(description = "Click the center of the selected window")]
+    pub async fn click_selected_window_center(
+        &self,
+        Parameters(params): Parameters<ClickParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let window_id = self
+            .selected_window()?
+            .ok_or_else(|| McpError::internal_error("No window selected. Use select_window/select_active_window/select_first_window first.", None))?;
+        let (_, _, width, height, _) = self.window_geometry(&window_id)?;
+        let rel_x = (width / 2).max(1).to_string();
+        let rel_y = (height / 2).max(1).to_string();
+        let button = params.button.to_string();
+        let output = Self::run_xdotool(&[
+            "windowactivate", "--sync", &window_id,
+            "mousemove", "--window", &window_id, &rel_x, &rel_y,
+            "click", &button,
+        ])?;
+        if output.status.success() {
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Clicked {} window center for {}",
+                Self::button_name(params.button), window_id
+            ))]))
+        } else {
+            Err(Self::xdotool_error(&output))
+        }
+    }
+
+    #[rmcp::tool(description = "Show a short summary of the selected window")]
+    pub async fn describe_selected_window(&self) -> Result<CallToolResult, McpError> {
+        let window_id = self
+            .selected_window()?
+            .ok_or_else(|| McpError::internal_error("No window selected. Use select_window/select_active_window/select_first_window first.", None))?;
+        let name = self.window_name(&window_id).unwrap_or_else(|| "<unknown>".to_string());
+        let (x, y, width, height, screen) = self.window_geometry(&window_id)?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Selected window: {} ({})\nPosition: ({}, {})\nSize: {}x{}\nScreen: {}",
+            window_id, name, x, y, width, height, screen
+        ))]))
     }
 
     #[rmcp::tool(description = "Get the currently focused/active window ID")]
@@ -499,43 +647,11 @@ impl XdotoolServer {
         let window_id = self
             .resolve_window_id(params.window_id.as_deref())?
             .ok_or_else(|| McpError::internal_error("No window selected. Pass a window_id or use select_window/select_active_window first.", None))?;
-        let output = Command::new("xdotool")
-            .args(["getwindowgeometry", "--shell", &window_id])
-            .output()
-            .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
-
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let mut x = 0;
-            let mut y = 0;
-            let mut width = 0;
-            let mut height = 0;
-            let mut screen = 0;
-
-            for line in stdout.lines() {
-                if line.starts_with("X=") {
-                    x = line[2..].parse().unwrap_or(0);
-                } else if line.starts_with("Y=") {
-                    y = line[2..].parse().unwrap_or(0);
-                } else if line.starts_with("WIDTH=") {
-                    width = line[6..].parse().unwrap_or(0);
-                } else if line.starts_with("HEIGHT=") {
-                    height = line[7..].parse().unwrap_or(0);
-                } else if line.starts_with("SCREEN=") {
-                    screen = line[7..].parse().unwrap_or(0);
-                }
-            }
-
-            Ok(CallToolResult::success(vec![Content::text(
-                format!("Window {} geometry:\n  Position: ({}, {})\n  Size: {}x{}\n  Screen: {}",
-                    window_id, x, y, width, height, screen)
-            )]))
-        } else {
-            Err(McpError::internal_error(
-                format!("xdotool error: {}", String::from_utf8_lossy(&output.stderr)),
-                None
-            ))
-        }
+        let (x, y, width, height, screen) = self.window_geometry(&window_id)?;
+        Ok(CallToolResult::success(vec![Content::text(
+            format!("Window {} geometry:\n  Position: ({}, {})\n  Size: {}x{}\n  Screen: {}",
+                window_id, x, y, width, height, screen)
+        )]))
     }
 
     #[rmcp::tool(description = "Get the window title/name for a window ID")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use rmcp::{
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::process::Command;
+use std::{process::Command, sync::Mutex};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 // === Parameter Types ===
@@ -51,6 +51,9 @@ pub struct TypeTextParams {
     #[schemars(description = "Delay between keystrokes in milliseconds. Default: 12")]
     #[serde(default = "default_delay")]
     pub delay: u32,
+    #[schemars(description = "Optional window ID. Defaults to the selected window when set.")]
+    #[serde(default)]
+    pub window_id: Option<String>,
 }
 
 fn default_delay() -> u32 { 12 }
@@ -59,6 +62,9 @@ fn default_delay() -> u32 { 12 }
 pub struct KeyPressParams {
     #[schemars(description = "Key(s) to press. Examples: Return, Escape, ctrl+c, alt+Tab, super+1")]
     pub key: String,
+    #[schemars(description = "Optional window ID. Defaults to the selected window when set.")]
+    #[serde(default)]
+    pub window_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -85,7 +91,14 @@ fn default_search_type() -> String { "any".to_string() }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct WindowIdParams {
-    #[schemars(description = "Window ID (from search_window or get_active_window)")]
+    #[schemars(description = "Optional window ID. Defaults to the selected window when set.")]
+    #[serde(default)]
+    pub window_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SelectWindowParams {
+    #[schemars(description = "Window ID to save as the selected window")]
     pub window_id: String,
 }
 
@@ -94,6 +107,7 @@ pub struct WindowIdParams {
 #[derive(Debug)]
 pub struct XdotoolServer {
     pub tool_router: ToolRouter<Self>,
+    pub selected_window: Mutex<Option<String>>,
 }
 
 impl Default for XdotoolServer {
@@ -106,6 +120,7 @@ impl XdotoolServer {
     pub fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
+            selected_window: Mutex::new(None),
         }
     }
 
@@ -115,6 +130,34 @@ impl XdotoolServer {
             2 => "middle",
             3 => "right",
             _ => "unknown"
+        }
+    }
+
+    fn selected_window(&self) -> Result<Option<String>, McpError> {
+        self.selected_window
+            .lock()
+            .map(|guard| guard.clone())
+            .map_err(|_| McpError::internal_error("Failed to read selected window", None))
+    }
+
+    fn set_selected_window(&self, window_id: String) -> Result<(), McpError> {
+        *self.selected_window
+            .lock()
+            .map_err(|_| McpError::internal_error("Failed to update selected window", None))? = Some(window_id);
+        Ok(())
+    }
+
+    fn clear_selected_window_state(&self) -> Result<(), McpError> {
+        *self.selected_window
+            .lock()
+            .map_err(|_| McpError::internal_error("Failed to clear selected window", None))? = None;
+        Ok(())
+    }
+
+    fn resolve_window_id(&self, window_id: Option<&str>) -> Result<Option<String>, McpError> {
+        match window_id.filter(|id| !id.trim().is_empty()) {
+            Some(window_id) => Ok(Some(window_id.to_string())),
+            None => self.selected_window(),
         }
     }
 }
@@ -195,14 +238,24 @@ impl XdotoolServer {
         &self,
         Parameters(params): Parameters<TypeTextParams>,
     ) -> Result<CallToolResult, McpError> {
-        let output = Command::new("xdotool")
-            .args(["type", "--delay", &params.delay.to_string(), &params.text])
+        let delay = params.delay.to_string();
+        let selected_window = self.resolve_window_id(params.window_id.as_deref())?;
+        let mut command = Command::new("xdotool");
+        command.arg("type");
+        if let Some(window_id) = selected_window.as_deref() {
+            command.args(["--window", window_id]);
+        }
+        let output = command
+            .args(["--delay", &delay, &params.text])
             .output()
             .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
 
         if output.status.success() {
             Ok(CallToolResult::success(vec![Content::text(
-                format!("Typed: \"{}\"", params.text)
+                match selected_window {
+                    Some(window_id) => format!("Typed in window {}: \"{}\"", window_id, params.text),
+                    None => format!("Typed: \"{}\"", params.text),
+                }
             )]))
         } else {
             Err(McpError::internal_error(
@@ -217,14 +270,23 @@ impl XdotoolServer {
         &self,
         Parameters(params): Parameters<KeyPressParams>,
     ) -> Result<CallToolResult, McpError> {
-        let output = Command::new("xdotool")
-            .args(["key", &params.key])
+        let selected_window = self.resolve_window_id(params.window_id.as_deref())?;
+        let mut command = Command::new("xdotool");
+        command.arg("key");
+        if let Some(window_id) = selected_window.as_deref() {
+            command.args(["--window", window_id]);
+        }
+        let output = command
+            .arg(&params.key)
             .output()
             .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
 
         if output.status.success() {
             Ok(CallToolResult::success(vec![Content::text(
-                format!("Pressed key: {}", params.key)
+                match selected_window {
+                    Some(window_id) => format!("Pressed key in window {}: {}", window_id, params.key),
+                    None => format!("Pressed key: {}", params.key),
+                }
             )]))
         } else {
             Err(McpError::internal_error(
@@ -357,6 +419,58 @@ impl XdotoolServer {
         }
     }
 
+    #[rmcp::tool(description = "Save a window ID as the selected window for repeated tool calls")]
+    pub async fn select_window(
+        &self,
+        Parameters(params): Parameters<SelectWindowParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.set_selected_window(params.window_id.clone())?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Selected window: {}",
+            params.window_id
+        ))]))
+    }
+
+    #[rmcp::tool(description = "Save the current active window as the selected window")]
+    pub async fn select_active_window(&self) -> Result<CallToolResult, McpError> {
+        let output = Command::new("xdotool")
+            .args(["getactivewindow"])
+            .output()
+            .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
+
+        if output.status.success() {
+            let window_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            self.set_selected_window(window_id.clone())?;
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Selected active window: {}",
+                window_id
+            ))]))
+        } else {
+            Err(McpError::internal_error(
+                format!("xdotool error: {}", String::from_utf8_lossy(&output.stderr)),
+                None
+            ))
+        }
+    }
+
+    #[rmcp::tool(description = "Show the selected window, if one is set")]
+    pub async fn get_selected_window(&self) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![Content::text(
+            match self.selected_window()? {
+                Some(window_id) => format!("Selected window: {}", window_id),
+                None => "No window selected".to_string(),
+            }
+        )]))
+    }
+
+    #[rmcp::tool(description = "Clear the selected window")]
+    pub async fn clear_selected_window(&self) -> Result<CallToolResult, McpError> {
+        self.clear_selected_window_state()?;
+        Ok(CallToolResult::success(vec![Content::text(
+            "Cleared selected window".to_string()
+        )]))
+    }
+
     #[rmcp::tool(description = "Get the currently focused/active window ID")]
     pub async fn get_active_window(&self) -> Result<CallToolResult, McpError> {
         let output = Command::new("xdotool")
@@ -382,8 +496,11 @@ impl XdotoolServer {
         &self,
         Parameters(params): Parameters<WindowIdParams>,
     ) -> Result<CallToolResult, McpError> {
+        let window_id = self
+            .resolve_window_id(params.window_id.as_deref())?
+            .ok_or_else(|| McpError::internal_error("No window selected. Pass a window_id or use select_window/select_active_window first.", None))?;
         let output = Command::new("xdotool")
-            .args(["getwindowgeometry", "--shell", &params.window_id])
+            .args(["getwindowgeometry", "--shell", &window_id])
             .output()
             .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
 
@@ -411,7 +528,7 @@ impl XdotoolServer {
 
             Ok(CallToolResult::success(vec![Content::text(
                 format!("Window {} geometry:\n  Position: ({}, {})\n  Size: {}x{}\n  Screen: {}",
-                    params.window_id, x, y, width, height, screen)
+                    window_id, x, y, width, height, screen)
             )]))
         } else {
             Err(McpError::internal_error(
@@ -426,15 +543,18 @@ impl XdotoolServer {
         &self,
         Parameters(params): Parameters<WindowIdParams>,
     ) -> Result<CallToolResult, McpError> {
+        let window_id = self
+            .resolve_window_id(params.window_id.as_deref())?
+            .ok_or_else(|| McpError::internal_error("No window selected. Pass a window_id or use select_window/select_active_window first.", None))?;
         let output = Command::new("xdotool")
-            .args(["getwindowname", &params.window_id])
+            .args(["getwindowname", &window_id])
             .output()
             .map_err(|e| McpError::internal_error(format!("Failed to run xdotool: {}", e), None))?;
 
         if output.status.success() {
             let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
             Ok(CallToolResult::success(vec![Content::text(
-                format!("Window {} title: {}", params.window_id, name)
+                format!("Window {} title: {}", window_id, name)
             )]))
         } else {
             Err(McpError::internal_error(


### PR DESCRIPTION
Makes repeated window actions easier.

Refs:
- #5

Adds:
- select from search results
- focus the selected window
- describe the selected window
- click the selected window center

Fixes:
- real search errors are no longer hidden as "no windows"
- selected window ids are validated before saving

Checked on top of #1:
- cargo check --locked
- cargo test --locked
